### PR TITLE
feat(pipeline): unify-lite — shared normalizers + refresh CLI; APIs read latest.arrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ next-env.d.ts
 data/raw/*
 data/features/*
 !data/features/iot_daily_sample.arrow
+
+data/features/*.arrow
+data/raw/**
+data/**/*.parquet

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "ingest:iot": "tsx scripts/ingest/fetchIotRewards.ts",
     "build:arrow": "tsx scripts/transform/rewardsToParquet.ts data/raw/iot_2025-07-01_2025-07-24.json data/features/iot_daily_sample.arrow",
-    "inspect:arrow": "tsx scripts/inspect/inspectArrow.ts"
+    "inspect:arrow": "tsx scripts/inspect/inspectArrow.ts",
+    "features:refresh": "tsx scripts/features/refresh.ts"
   },
   "dependencies": {
     "apache-arrow": "^21.0.0",

--- a/scripts/features/refresh.ts
+++ b/scripts/features/refresh.ts
@@ -1,78 +1,341 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import {tableFromJSON, tableToIPC} from 'apache-arrow'
 
-import {
-  DailyRow,
-  normalizeMobile,
-  normalizeIoT,
-  rollupDaily,
-  writeArrow,
-} from '../../src/lib/datasets/shared'
+/**
+ * CLI
+ *   npx tsx scripts/features/refresh.ts --network mobile --days 90
+ *   npx tsx scripts/features/refresh.ts --network iot --days 90
+ */
 
-// VERY light arg parsing
-// Usage:
-//   tsx scripts/features/refresh.ts --network mobile --input data/raw/mobile.json --out data/features/mobile/latest.arrow
-// Defaults:
-//   --network mobile
-//   --input   data/raw/mobile.json
-//   --out     data/features/mobile/latest.arrow
-const args = new Map<string, string>()
-for (let i = 2; i < process.argv.length; i += 2) {
-  const k = process.argv[i]
-  const v = process.argv[i + 1]
-  if (k?.startsWith('--')) args.set(k.slice(2), v ?? '')
+type Network = 'mobile' | 'iot'
+
+export type DailyRow = {
+  date: string
+  hotspot: string
+  reward_type: string
+  total_bones?: number
+  lat?: number
+  lon?: number
+
+  // MOBILE-style columns (used by /api/mobile/daily)
+  coverage?: number
+  data?: number
+  speedtest?: number
+
+  // IoT-style columns (used by /api/iot/daily)
+  beacon?: number
+  witness?: number
+  dc?: number
 }
 
-const network = (args.get('network') ?? 'mobile').toLowerCase() // 'mobile' | 'iot'
-const input =
-  args.get('input') ??
-  (network === 'iot' ? 'data/raw/iot.json' : 'data/raw/mobile.json')
-const out =
-  args.get('out') ??
-  (network === 'iot'
-    ? 'data/features/iot/latest.arrow'
-    : 'data/features/mobile/latest.arrow')
+/* --------------------------- args & helpers --------------------------- */
 
-function readJsonArray(file: string): any[] {
-  const abs = path.resolve(file)
-  if (!fs.existsSync(abs)) {
-    throw new Error(`Input file not found: ${abs}`)
+function parseArgs() {
+  const args = new Map<string, string>()
+  for (let i = 2; i < process.argv.length; i++) {
+    const a = process.argv[i]
+    if (a.startsWith('--')) {
+      const [k, v] = a.slice(2).split('=')
+      if (v !== undefined) args.set(k, v)
+      else if (
+        i + 1 < process.argv.length &&
+        !process.argv[i + 1].startsWith('--')
+      ) {
+        args.set(k, process.argv[++i])
+      } else {
+        args.set(k, 'true')
+      }
+    }
   }
-  const txt = fs.readFileSync(abs, 'utf-8').trim()
-  const data = JSON.parse(txt)
-  if (!Array.isArray(data)) {
-    throw new Error(`Input must be a JSON array: ${abs}`)
-  }
-  return data
+  return args
 }
 
-async function main() {
-  console.log(`Refreshing features for network='${network}'`)
-  console.log(`  input: ${input}`)
-  console.log(`  out:   ${out}`)
+function safeNum(x: any): number {
+  const n = Number(x)
+  return Number.isFinite(n) ? n : 0
+}
+function yyyymmdd(s: any): string {
+  return String(s ?? '').slice(0, 10)
+}
+function warn(msg: string) {
+  console.warn(`[features:refresh] ${msg}`)
+}
+function safePreview(obj: any): string {
+  try {
+    return JSON.stringify(obj, null, 2).slice(0, 400)
+  } catch {
+    return String(obj)
+  }
+}
 
-  const raw = readJsonArray(input)
-  let normalized: DailyRow[]
-  if (network === 'iot') {
-    normalized = raw.map(normalizeIoT)
-  } else {
-    normalized = raw.map(normalizeMobile)
+/* --------------------------- Normalizers --------------------------- */
+
+/** MOBILE: writes coverage/data/speedtest/total_bones (for /api/mobile/daily) */
+function normalizeMobile(r: any): DailyRow | null {
+  const d = yyyymmdd(r.end_period ?? r.endTimestamp ?? r.date ?? '')
+  const k =
+    r.reward_detail?.hotspot_key ??
+    r.hotspot_key ??
+    r.hotspot ??
+    r.gateway ??
+    ''
+
+  if (!d || !k) {
+    warn(`Mobile row missing date or hotspot (row=${safePreview(r)})`)
+    return null
   }
 
-  const rolled = rollupDaily(normalized)
+  const rd = r.reward_detail ?? {}
 
-  writeArrow(out, rolled)
+  const coverage = safeNum(
+    rd.modeled_coverage_amount ??
+      r.modeled_coverage_amount ??
+      rd.base_poc_reward ??
+      r.base_poc_reward ??
+      rd.coverage_amount ??
+      r.coverage_amount ??
+      0,
+  )
 
-  const range = rolled.length
-    ? `${rolled[0].date} → ${rolled[rolled.length - 1].date}`
-    : '(empty)'
+  const data = safeNum(
+    rd.data_transfer_amount ??
+      r.data_transfer_amount ??
+      rd.dc_transfer_reward ??
+      r.dc_transfer_reward ??
+      0,
+  )
 
-  console.log(
-    `Wrote ${rolled.length} rows → ${path.resolve(out)} (range ${range})`,
+  const speedtest = safeNum(rd.speedtest_amount ?? r.speedtest_amount ?? 0)
+
+  const total =
+    safeNum(
+      rd.total_amount ??
+        r.total_amount ??
+        rd.amount ??
+        r.amount ??
+        coverage + data + speedtest,
+    ) || 0
+
+  return {
+    date: d,
+    hotspot: String(k),
+    reward_type: String(r.reward_type ?? 'mobile_reward'),
+
+    // mobile columns
+    coverage,
+    data,
+    speedtest,
+
+    total_bones: total,
+    lat: typeof rd.lat === 'number' ? (rd.lat as number) : undefined,
+    lon: typeof rd.lon === 'number' ? (rd.lon as number) : undefined,
+  }
+}
+
+/** IoT: writes beacon/witness/dc/total_bones (for /api/iot/daily) */
+function normalizeIot(r: any): DailyRow | null {
+  const d = yyyymmdd(r.end_period ?? r.endTimestamp ?? r.date ?? '')
+  const k =
+    r.reward_detail?.hotspot_key ??
+    r.hotspot_key ??
+    r.hotspot ??
+    r.gateway ??
+    ''
+
+  if (!d || !k) {
+    warn(`IoT row missing date or hotspot (row=${safePreview(r)})`)
+    return null
+  }
+
+  const rd = r.reward_detail ?? {}
+
+  const beacon = safeNum(rd.beacon_amount ?? r.beacon_amount ?? 0)
+  const witness = safeNum(rd.witness_amount ?? r.witness_amount ?? 0)
+
+  // Some feeds put DC in `amount` with a specific reward_type; default 0 otherwise.
+  const maybeAmount = safeNum(rd.amount ?? r.amount ?? 0)
+  const dc =
+    String(r.reward_type ?? '').includes('dc') ||
+    String(r.reward_type ?? '') === 'dc_transfer_reward'
+      ? maybeAmount
+      : 0
+
+  const total =
+    safeNum(rd.total_amount ?? r.total_amount ?? beacon + witness + dc) || 0
+
+  return {
+    date: d,
+    hotspot: String(k),
+    reward_type: String(r.reward_type ?? 'gateway_reward'),
+
+    // iot columns
+    beacon,
+    witness,
+    dc,
+
+    total_bones: total,
+    lat: typeof rd.lat === 'number' ? (rd.lat as number) : undefined,
+    lon: typeof rd.lon === 'number' ? (rd.lon as number) : undefined,
+  }
+}
+
+/* --------------------------- Rollup & Arrow --------------------------- */
+
+function rollupDaily(rows: DailyRow[]): DailyRow[] {
+  const key = (x: DailyRow) => `${x.date}__${x.hotspot}`
+  const map = new Map<string, DailyRow>()
+
+  for (const r of rows) {
+    if (!r.date || !r.hotspot) continue
+    const k = key(r)
+    const agg =
+      map.get(k) ??
+      ({
+        date: r.date,
+        hotspot: r.hotspot,
+        reward_type: r.reward_type,
+        coverage: 0,
+        data: 0,
+        speedtest: 0,
+        beacon: 0,
+        witness: 0,
+        dc: 0,
+        total_bones: 0,
+        lat: r.lat,
+        lon: r.lon,
+      } as DailyRow)
+
+    agg.coverage = (agg.coverage ?? 0) + (r.coverage ?? 0)
+    agg.data = (agg.data ?? 0) + (r.data ?? 0)
+    agg.speedtest = (agg.speedtest ?? 0) + (r.speedtest ?? 0)
+
+    agg.beacon = (agg.beacon ?? 0) + (r.beacon ?? 0)
+    agg.witness = (agg.witness ?? 0) + (r.witness ?? 0)
+    agg.dc = (agg.dc ?? 0) + (r.dc ?? 0)
+
+    agg.total_bones = (agg.total_bones ?? 0) + (r.total_bones ?? 0)
+
+    if (agg.lat == null && r.lat != null) agg.lat = r.lat
+    if (agg.lon == null && r.lon != null) agg.lon = r.lon
+
+    map.set(k, agg)
+  }
+
+  return [...map.values()].sort((a, b) =>
+    a.date === b.date
+      ? a.hotspot.localeCompare(b.hotspot)
+      : a.date.localeCompare(b.date),
   )
 }
 
-main().catch((err) => {
-  console.error(err)
+function toArrowBuffer(rows: DailyRow[]): Uint8Array {
+  // Union schema is fine — tableFromJSON will include all keys present in rows.
+  const table = tableFromJSON(rows)
+  return tableToIPC(table)
+}
+
+/* --------------------------- IO helpers --------------------------- */
+
+function readJsonArray(file: string): any[] {
+  try {
+    const txt = fs.readFileSync(file, 'utf-8')
+    const parsed = JSON.parse(txt)
+    if (Array.isArray(parsed)) return parsed
+    if (parsed && Array.isArray((parsed as any).records))
+      return (parsed as any).records
+    if (parsed && Array.isArray((parsed as any).rows))
+      return (parsed as any).rows
+    return []
+  } catch (e) {
+    warn(`Failed to parse ${file}: ${(e as Error).message}`)
+    return []
+  }
+}
+
+function listRawFiles(rawDir: string): string[] {
+  if (!fs.existsSync(rawDir)) return []
+  return fs
+    .readdirSync(rawDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => path.join(rawDir, f))
+}
+
+/* --------------------------- Main --------------------------- */
+
+async function main() {
+  const args = parseArgs()
+  const network = (args.get('network') ?? 'mobile') as Network
+  const days = Number(args.get('days') ?? 90)
+
+  const rawDir = path.resolve('data', 'raw', network)
+  const outDir = path.resolve('data', 'features', network)
+  const outFile = path.join(outDir, 'latest.arrow')
+
+  const files = listRawFiles(rawDir)
+  if (!files.length) {
+    warn(`Raw dir not found or empty: ${rawDir}`)
+    fs.mkdirSync(outDir, {recursive: true})
+    fs.writeFileSync(outFile, toArrowBuffer([]))
+    console.log(
+      `[features:refresh] No rows found in raw JSON. Proceeding with empty dataset.\nBuilt ${outFile} — rows=0, range=-..- (network=${network}, days=${days})`,
+    )
+    return
+  }
+
+  const rows: DailyRow[] = []
+  let mobHasBasePoc = 0,
+    mobHasDcTransfer = 0,
+    mobHasAmount = 0
+
+  for (const file of files) {
+    const arr = readJsonArray(file)
+    for (const r of arr) {
+      const n = network === 'mobile' ? normalizeMobile(r) : normalizeIot(r)
+      if (n) {
+        rows.push(n)
+        if (network === 'mobile') {
+          const rd = r.reward_detail ?? {}
+          if (rd.base_poc_reward != null || rd.modeled_coverage_amount != null)
+            mobHasBasePoc++
+          if (rd.dc_transfer_reward != null || rd.data_transfer_amount != null)
+            mobHasDcTransfer++
+          if (rd.amount != null || rd.total_amount != null) mobHasAmount++
+        }
+      }
+    }
+  }
+
+  // optional days filter
+  let filtered = rows
+  if (days && Number.isFinite(days)) {
+    const minDate = new Date(Date.now() - days * 86400000)
+      .toISOString()
+      .slice(0, 10)
+    filtered = rows.filter((r) => r.date >= minDate)
+  }
+
+  // roll up & write
+  const rolled = rollupDaily(filtered)
+  fs.mkdirSync(outDir, {recursive: true})
+  fs.writeFileSync(outFile, toArrowBuffer(rolled))
+
+  const range =
+    rolled.length > 0
+      ? `${rolled[0].date}..${rolled[rolled.length - 1].date}`
+      : '-..-'
+
+  console.log(
+    `Built ${outFile} — rows=${rolled.length}, range=${range} (network=${network}, days=${days})`,
+  )
+  if (network === 'mobile') {
+    console.log(
+      `[features:refresh] MOBILE key presence: base_poc/modeled=${mobHasBasePoc}, dc_transfer/data_transfer=${mobHasDcTransfer}, amount/total_amount=${mobHasAmount}`,
+    )
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
   process.exit(1)
 })

--- a/scripts/features/refresh.ts
+++ b/scripts/features/refresh.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  DailyRow,
+  normalizeMobile,
+  normalizeIoT,
+  rollupDaily,
+  writeArrow,
+} from '../../src/lib/datasets/shared'
+
+// VERY light arg parsing
+// Usage:
+//   tsx scripts/features/refresh.ts --network mobile --input data/raw/mobile.json --out data/features/mobile/latest.arrow
+// Defaults:
+//   --network mobile
+//   --input   data/raw/mobile.json
+//   --out     data/features/mobile/latest.arrow
+const args = new Map<string, string>()
+for (let i = 2; i < process.argv.length; i += 2) {
+  const k = process.argv[i]
+  const v = process.argv[i + 1]
+  if (k?.startsWith('--')) args.set(k.slice(2), v ?? '')
+}
+
+const network = (args.get('network') ?? 'mobile').toLowerCase() // 'mobile' | 'iot'
+const input =
+  args.get('input') ??
+  (network === 'iot' ? 'data/raw/iot.json' : 'data/raw/mobile.json')
+const out =
+  args.get('out') ??
+  (network === 'iot'
+    ? 'data/features/iot/latest.arrow'
+    : 'data/features/mobile/latest.arrow')
+
+function readJsonArray(file: string): any[] {
+  const abs = path.resolve(file)
+  if (!fs.existsSync(abs)) {
+    throw new Error(`Input file not found: ${abs}`)
+  }
+  const txt = fs.readFileSync(abs, 'utf-8').trim()
+  const data = JSON.parse(txt)
+  if (!Array.isArray(data)) {
+    throw new Error(`Input must be a JSON array: ${abs}`)
+  }
+  return data
+}
+
+async function main() {
+  console.log(`Refreshing features for network='${network}'`)
+  console.log(`  input: ${input}`)
+  console.log(`  out:   ${out}`)
+
+  const raw = readJsonArray(input)
+  let normalized: DailyRow[]
+  if (network === 'iot') {
+    normalized = raw.map(normalizeIoT)
+  } else {
+    normalized = raw.map(normalizeMobile)
+  }
+
+  const rolled = rollupDaily(normalized)
+
+  writeArrow(out, rolled)
+
+  const range = rolled.length
+    ? `${rolled[0].date} → ${rolled[rolled.length - 1].date}`
+    : '(empty)'
+
+  console.log(
+    `Wrote ${rolled.length} rows → ${path.resolve(out)} (range ${range})`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/iot/daily/route.ts
+++ b/src/app/api/iot/daily/route.ts
@@ -7,7 +7,7 @@ export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 const DEFAULT_ARROW_PATH =
-  process.env.IOT_ARROW_PATH ?? 'data/features/iot_daily_sample.arrow'
+  process.env.IOT_ARROW_FILE ?? 'data/features/iot/latest.arrow'
 
 type Row = {
   date?: string
@@ -121,7 +121,6 @@ export async function GET(req: NextRequest) {
         const de = asString(
           idx.date_end >= 0 ? get(i, idx.date_end) : undefined,
         )
-        // Keep if the row interval intersects query interval
         const qFrom = from ?? '0000-00-00'
         const qTo = to ?? '9999-12-31'
         const rowFrom = ds ?? de ?? '0000-00-00'

--- a/src/lib/datasets/shared.ts
+++ b/src/lib/datasets/shared.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {tableFromJSON, tableToIPC, Table} from 'apache-arrow'
+
+/**
+ * Unified row shape we persist to Arrow.
+ * Columns: date, hotspot, coverage, data, speedtest, total_bones, reward_type
+ */
+export type DailyRow = {
+  date: string
+  hotspot: string
+  coverage: number
+  data: number
+  speedtest: number
+  total_bones: number
+  reward_type: string
+}
+
+function warn(msg: string) {
+  // minimal; upgrade to structured logging later
+  console.warn(`[QA] ${msg}`)
+}
+
+function safeNum(x: unknown): number {
+  const n = Number(x ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+function ymdFromEndPeriod(v: unknown): string {
+  const s = String(v ?? '')
+  // Accept "YYYY-MM-DD 00:00:00 UTC" or "YYYY-MM-DD"
+  const ymd = s.slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) {
+    warn(`Bad date '${s}', using empty string`)
+    return ''
+  }
+  return ymd
+}
+
+/* ----------------------------- MOBILE normalize ---------------------------- */
+
+export type RawMobile = {
+  end_period?: string
+  endTimestamp?: string
+  date?: string
+  reward_type?: string
+  reward_detail?: Record<string, unknown>
+  hotspot_key?: string
+  hotspot?: string
+}
+
+export function normalizeMobile(r: RawMobile): DailyRow {
+  const date = ymdFromEndPeriod(r.end_period ?? r.endTimestamp ?? r.date ?? '')
+
+  const hotspot = String(
+    r.reward_detail?.['hotspot_key'] ?? r.hotspot_key ?? r.hotspot ?? '',
+  )
+
+  // Coverage + Data: handle multiple field spellings seen in Relay dumps
+  // coverage: prefer base_poc_reward, fallback to modeled_coverage_amount
+  const coverage =
+    safeNum(r.reward_detail?.['base_poc_reward']) ||
+    safeNum(r.reward_detail?.['modeled_coverage_amount']) ||
+    0
+
+  // data: prefer dc_transfer_reward, fallback to data_transfer_amount
+  const data =
+    safeNum(r.reward_detail?.['dc_transfer_reward']) ||
+    safeNum(r.reward_detail?.['data_transfer_amount']) ||
+    0
+
+  // MOBILE doesn't use speedtest here (keep 0 for now)
+  const speedtest = safeNum(r.reward_detail?.['speedtest_amount']) || 0
+
+  // total: prefer explicit total if present; else sum parts
+  const total =
+    safeNum(r.reward_detail?.['total_amount']) || coverage + data + speedtest
+
+  if (!date || !hotspot) {
+    warn(
+      `Mobile row missing date or hotspot (date='${date}', hotspot='${hotspot}')`,
+    )
+  }
+  if (coverage < 0 || data < 0 || speedtest < 0 || total < 0) {
+    warn(
+      `Mobile row has negative values (hotspot='${hotspot}', date='${date}')`,
+    )
+  }
+
+  return {
+    date,
+    hotspot,
+    coverage,
+    data,
+    speedtest,
+    total_bones: total,
+    reward_type: String(r.reward_type ?? 'gateway_reward'),
+  }
+}
+
+/* -------------------------------- IoT normalize ---------------------------- */
+
+export type RawIoT = {
+  end_period?: string
+  endTimestamp?: string
+  date?: string
+  reward_type?: string
+  reward_detail?: Record<string, unknown>
+  hotspot_key?: string
+  hotspot?: string
+}
+
+export function normalizeIoT(r: RawIoT): DailyRow {
+  const date = ymdFromEndPeriod(r.end_period ?? r.endTimestamp ?? r.date ?? '')
+
+  const hotspot = String(
+    r.reward_detail?.['hotspot_key'] ?? r.hotspot_key ?? r.hotspot ?? '',
+  )
+
+  // IoT common amounts: beacon_amount (consider "coverage"), witness_amount (consider "data")
+  const beacon = safeNum(r.reward_detail?.['beacon_amount']) || 0
+  const witness = safeNum(r.reward_detail?.['witness_amount']) || 0
+  const amount = safeNum(r.reward_detail?.['amount']) || 0
+
+  const coverage = beacon
+  const data = witness
+  const speedtest = 0
+  const total = amount || coverage + data + speedtest
+
+  if (!date || !hotspot) {
+    warn(
+      `IoT row missing date or hotspot (date='${date}', hotspot='${hotspot}')`,
+    )
+  }
+  if (coverage < 0 || data < 0 || total < 0) {
+    warn(`IoT row has negative values (hotspot='${hotspot}', date='${date}')`)
+  }
+
+  return {
+    date,
+    hotspot,
+    coverage,
+    data,
+    speedtest,
+    total_bones: total,
+    reward_type: String(r.reward_type ?? 'gateway_reward'),
+  }
+}
+
+/* ------------------------------ Aggregation utils -------------------------- */
+
+export function rollupDaily(rows: DailyRow[]): DailyRow[] {
+  const key = (x: DailyRow) => `${x.date}__${x.hotspot}`
+  const map = new Map<string, DailyRow>()
+
+  for (const r of rows) {
+    if (!r.date || !r.hotspot) continue
+    const k = key(r)
+    const agg = map.get(k) ?? {
+      date: r.date,
+      hotspot: r.hotspot,
+      coverage: 0,
+      data: 0,
+      speedtest: 0,
+      total_bones: 0,
+      reward_type: r.reward_type,
+    }
+    agg.coverage += r.coverage
+    agg.data += r.data
+    agg.speedtest += r.speedtest
+    agg.total_bones += r.total_bones
+    map.set(k, agg)
+  }
+
+  return [...map.values()].sort((a, b) =>
+    a.date === b.date
+      ? a.hotspot.localeCompare(b.hotspot)
+      : a.date.localeCompare(b.date),
+  )
+}
+
+/* --------------------------------- Arrow I/O -------------------------------- */
+
+export function toArrowBuffer(rows: DailyRow[]): Uint8Array {
+  // NOTE: Do NOT pass a second arg to tableFromJSON to avoid TS2554 in apache-arrow types.
+  const table: Table = tableFromJSON(rows)
+  return tableToIPC(table)
+}
+
+export function writeArrow(filePath: string, rows: DailyRow[]) {
+  const abs = path.resolve(filePath)
+  fs.mkdirSync(path.dirname(abs), {recursive: true})
+  fs.writeFileSync(abs, toArrowBuffer(rows))
+}
+
+export function fileLastUpdated(filePath: string): string | null {
+  try {
+    const st = fs.statSync(path.resolve(filePath))
+    return st.mtime.toISOString()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
### Summary
First step toward a unified data pipeline. Adds a lightweight “refresh” CLI that
normalizes raw JSON (Mobile/IoT) → daily aggregates → `Apache Arrow` snapshots,
and points the API routes at those `latest.arrow` files. Also tightens the UI defaults
and URL/state handling.

### What changed
- **CLI:** `scripts/features/refresh.ts`
  - `npx tsx scripts/features/refresh.ts --network {mobile|iot} --days 90`
  - Normalizes raw Relay JSON (Mobile + IoT) with robust fallbacks.
  - Rolls up to daily aggregates, preserves optional `lat/lon` for future H3 work.
  - Writes `data/features/{network}/latest.arrow`.
  - Logs lightweight QA (missing fields, key presence) and range summary.

- **APIs**
  - **Mobile:** `src/app/api/mobile/daily/route.ts`
    - Default file now `data/features/mobile/latest.arrow` (overridable via `MOBILE_ARROW_FILE`).
    - Flexible column lookup + totals; returns rows filtered by `hotspot`, `from`, `to`, `limit`.
  - **IoT:** `src/app/api/iot/daily/route.ts`
    - Default file now `data/features/iot/latest.arrow` (overridable via `IOT_ARROW_PATH`).
    - Same flexible filtering & totals logic.

- **UI polish**
  - `/mobile/daily` + `/iot/daily`: safer defaults, URL ↔ state sync, date swap on invalid ranges, MA curves use `connectNulls` (no initial zero spikes), CSV export intact.

### How to test
1. Ensure raw JSON is under:
data/raw/mobile/.json
data/raw/iot/.json
