### PR TITLE
perf(netlify): mitigate cold starts with scheduled warm ping + higher lambda resources

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,11 @@
 [functions]
   # include the dataset in the lambda bundle
   included_files = ["data/features/iot/ca_iot_daily.arrow"]
+
+[functions."api/iot/h3/daily"]
+  memory = 1024
+  timeout = 25
+
+[[scheduled.functions]]
+  name = "warm-forecaster"
+  cron = "*/4 * * * *"

--- a/netlify/functions/warm-forecaster.ts
+++ b/netlify/functions/warm-forecaster.ts
@@ -1,0 +1,13 @@
+export async function handler() {
+  const base = process.env.URL || process.env.DEPLOY_URL || ''
+  const targets = [
+    `${base}/api/iot/h3/daily?forecast=true&horizon=1&hex=8828308291fffff&limit=1`,
+    `${base}/api/iot/h3/daily?from=2025-07-01&to=2025-07-02&limit=1`,
+  ]
+  try {
+    await Promise.allSettled(targets.map((u) => fetch(u)))
+    return {statusCode: 200, body: 'ok'}
+  } catch {
+    return {statusCode: 200, body: 'ok'}
+  }
+}


### PR DESCRIPTION
Description:

Keep api/iot/h3/daily warm via scheduled pings every 4 minutes (forecast + observed).

Increase function memory (1024MB) and timeout (25s) to stabilize ONNX init.

No changes to forecasting logic; observed sampling/CDN headers remain.

Goal: eliminate “works local, slow on preview” by avoiding cold starts on Netlify.
