### PR TITLE
chore(netlify): enable scheduled warm-forecaster (every 4m) + correct bundling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,13 @@
 [functions]
-  # include the dataset in the lambda bundle
-  included_files = ["data/features/iot/ca_iot_daily.arrow"]
+  node_bundler = "esbuild"
+  external_node_modules = ["onnxruntime-node"]
+  included_files = [
+    "node_modules/onnxruntime-node/**",
+    "public/models/**",
+    "data/features/iot/**"
+  ]
 
-[functions."api/iot/h3/daily"]
-  memory = 1024
-  timeout = 25
-
-[[scheduled.functions]]
-  name = "warm-forecaster"
-  cron = "*/4 * * * *"
+# Scheduled function (production only; cron is UTC)
+[[scheduled_functions]]
+  path = "warm-forecaster"
+  schedule = "*/4 * * * *"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,10 @@
     "data/features/iot/**"
   ]
 
+[functions."api/iot/h3/daily"]
+  memory = 1024
+  timeout = 25
+
 # Scheduled function (production only; cron is UTC)
 [[scheduled_functions]]
   path = "warm-forecaster"


### PR DESCRIPTION
## Summary

- Replace `[[scheduled.functions]]` with `[[scheduled_functions]]` using `path` / `schedule`.
- Schedule `warm-forecaster` every **4 minutes (UTC)**.
- **Preserve** per-function settings for `api/iot/h3/daily` (`memory=1024`, `timeout=25s`).
- Keep bundling for `onnxruntime-node`, `public/models/**`, and the Arrow dataset.
- No app logic changes; **production only** (won’t run on previews).

